### PR TITLE
feat: Make delivery and contract actions optional

### DIFF
--- a/contract/src/contribution.rs
+++ b/contract/src/contribution.rs
@@ -122,6 +122,10 @@ impl Contract {
                 // Get the specific contribution entry and change its status to accepted.
                 history.entry(cid.clone()).and_modify(|old| {
                     let mut contribution: Contribution = old.clone().into();
+                    require!(
+                        matches!(contribution.status, ContributionStatus::Created(_)),
+                        "ERR_CONTRIBUTION_ALREADY_RESPONDED_TO"
+                    );
                     contribution.status =
                         ContributionStatus::Accepted(near_sdk::env::block_timestamp());
                     *old = VersionedContribution::V0(contribution);
@@ -151,6 +155,10 @@ impl Contract {
                 // Get the specific contribution entry and change its status to rejected.
                 history.entry(cid.clone()).and_modify(|old| {
                     let mut contribution: Contribution = old.clone().into();
+                    require!(
+                        matches!(contribution.status, ContributionStatus::Created(_)),
+                        "ERR_CONTRIBUTION_ALREADY_RESPONDED_TO"
+                    );
                     contribution.status =
                         ContributionStatus::Rejected(near_sdk::env::block_timestamp());
                     *old = VersionedContribution::V0(contribution);
@@ -248,7 +256,8 @@ impl Contract {
                 history.entry(cid.clone()).and_modify(|old| {
                     let mut contribution: Contribution = old.clone().into();
                     require!(
-                        contribution.status == ContributionStatus::Ongoing,
+                        contribution.status == ContributionStatus::Ongoing
+                            || matches!(contribution.status, ContributionStatus::Accepted(_)),
                         "ERR_CONTRIBUTION_NOT_ONGOING"
                     );
                     contribution.status =
@@ -279,7 +288,9 @@ impl Contract {
                 history.entry(cid.clone()).and_modify(|old| {
                     let mut contribution: Contribution = old.clone().into();
                     require!(
-                        matches!(contribution.status, ContributionStatus::Delivered(_)),
+                        contribution.status == ContributionStatus::Ongoing
+                            || matches!(contribution.status, ContributionStatus::Accepted(_))
+                            || matches!(contribution.status, ContributionStatus::Delivered(_)),
                         "ERR_CONTRIBUTION_NOT_DELIVERED"
                     );
                     contribution.status =

--- a/widgets/src/Contribution/Page.jsx
+++ b/widgets/src/Contribution/Page.jsx
@@ -79,6 +79,11 @@ if (
   return <>Loading...</>;
 }
 
+const cStatus = state.contribution.status;
+const isAcceptable = typeof cStatus === "object" && "Created" in cStatus;
+const isDeliverable = typeof cStatus === "string" || "Accepted" in cStatus;
+const isCompletable = isDeliverable;
+
 const Container = styled.div`
   display: flex;
   flex-direction: column;
@@ -310,9 +315,7 @@ const contractAction = (actionType) => {
 };
 
 const vendorCreatedView =
-  state.isVendorAdmin &&
-  typeof state.contribution.status !== "string" &&
-  "Created" in state.contribution.status ? (
+  state.isVendorAdmin && isAcceptable ? (
     <>
       <Widget
         src={`${ownerId}/widget/Buttons.Green`}
@@ -370,9 +373,9 @@ const vendorCreatedView =
   ) : (
     <></>
   );
+
 const vendorAcceptedView =
-  (state.isVendorAdmin && typeof state.contribution.status === "string") ||
-  "Accepted" in state.contribution.status ? (
+  state.isVendorAdmin && isDeliverable ? (
     <Widget
       src={`${ownerId}/widget/Buttons.Grey`}
       props={{
@@ -404,9 +407,7 @@ const vendorAcceptedView =
   );
 
 const projectDeliveredView =
-  state.isProjectAdmin &&
-  typeof state.contribution.status !== "string" &&
-  "Delivered" in state.contribution.status ? (
+  state.isProjectAdmin && isCompletable ? (
     <Widget
       src={`${ownerId}/widget/Buttons.Grey`}
       props={{
@@ -475,21 +476,18 @@ const projectDeliveredView =
     <></>
   );
 
-const addActionView =
-  (typeof state.contribution.status !== "string" &&
-    "Accepted" in state.contribution.status) ||
-  state.contribution.status === "Ongoing" ? (
-    <Widget
-      src={`${ownerId}/widget/Contribution.ActionSideWindow`}
-      props={{
-        projectId,
-        vendorId,
-        cid,
-      }}
-    />
-  ) : (
-    <></>
-  );
+const addActionView = isDeliverable ? (
+  <Widget
+    src={`${ownerId}/widget/Contribution.ActionSideWindow`}
+    props={{
+      projectId,
+      vendorId,
+      cid,
+    }}
+  />
+) : (
+  <></>
+);
 
 return (
   <Container>


### PR DESCRIPTION
Enable service providers to deliver contracts upon acceptance without having to add actions
Enable projects to complete contracts upon acceptance without having to add actions or wait for service provider to deliver contracts